### PR TITLE
Increase heading deadband for AbsoluteDrive.

### DIFF
--- a/src/main/deploy/swerve/neo/controllerproperties.json
+++ b/src/main/deploy/swerve/neo/controllerproperties.json
@@ -1,5 +1,5 @@
 {
-  "angleJoystickRadiusDeadband": 0.5,
+  "angleJoystickRadiusDeadband": 0.75,
   "heading": {
     "p": 0.4,
     "i": 0,


### PR DESCRIPTION
Even at 50% deadband, heading is too close to center of stick.