### PR TITLE
Add code and plumbing for setting motor current limits.

### DIFF
--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -113,6 +113,19 @@ public final class Constants
         public static final double SIM_AVG_LATENCY_MS = 67.0;
     }
 
+    public static class MotorLimit {
+      public static class Neo {
+        public static final int stall = 60;
+        public static final int free  = 30;
+        public static final int stallRPM = 0; // 0 for linear limit
+      }
+      public static class Neo550 {
+        public static final int stall = 40;
+        public static final int free  = 20;
+        public static final int stallRPM = 0; // 0 for linear limit
+      }
+    }
+
     public static final HolonomicPathFollowerConfig pathFollowerConfig = new HolonomicPathFollowerConfig(
       new PIDConstants(0.0020645, 0, 0), // Translation constants 
       new PIDConstants(0.03, 0, 0), // Rotation constants 

--- a/src/main/java/frc/robot/RobotContainer.java
+++ b/src/main/java/frc/robot/RobotContainer.java
@@ -42,6 +42,7 @@ import frc.robot.subsystems.climber.climberRightSubsystem;
 import frc.robot.subsystems.swervedrive.SwerveSubsystem;
 
 import java.io.File;
+import java.util.List;
 
 import com.pathplanner.lib.auto.AutoBuilder;
 import com.pathplanner.lib.auto.NamedCommands;

--- a/src/main/java/frc/robot/subsystems/arm/armSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/arm/armSubsystem.java
@@ -4,6 +4,8 @@
  
 package frc.robot.subsystems.arm;
 
+import java.util.List;
+
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.CANSparkLowLevel.MotorType;
 
@@ -12,6 +14,7 @@ import edu.wpi.first.math.controller.ProfiledPIDController;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
 import edu.wpi.first.math.trajectory.TrapezoidProfile.State;
 import edu.wpi.first.wpilibj.DutyCycleEncoder;
+import frc.robot.Constants;
 import frc.robot.Constants.Arm;
 import edu.wpi.first.wpilibj2.command.ProfiledPIDSubsystem;
 
@@ -19,7 +22,15 @@ import edu.wpi.first.wpilibj2.command.ProfiledPIDSubsystem;
 public class armSubsystem extends ProfiledPIDSubsystem {
   private CANSparkMax leftMotor = new CANSparkMax(Arm.kLeftMotorPort, MotorType.kBrushless);
   private CANSparkMax rightMotor = new CANSparkMax(Arm.kRightMotorPort, MotorType.kBrushless);
-  
+  {
+    for( var motor : List.of(leftMotor, rightMotor) ) {
+      motor.setSmartCurrentLimit(
+          Constants.MotorLimit.Neo.stall,
+          Constants.MotorLimit.Neo.free,
+          Constants.MotorLimit.Neo.stallRPM);
+    }
+  }
+
   public DutyCycleEncoder m_encoder = new DutyCycleEncoder(4);
   
   private final ArmFeedforward m_feedforward =

--- a/src/main/java/frc/robot/subsystems/arm/intakeSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/arm/intakeSubsystem.java
@@ -6,10 +6,18 @@ import com.revrobotics.CANSparkMax;
 import edu.wpi.first.wpilibj.DigitalInput;
 import edu.wpi.first.wpilibj.RobotController;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants;
 
 public class intakeSubsystem extends SubsystemBase {
     
     private final CANSparkMax intakeMotor = new CANSparkMax(29, MotorType.kBrushless);
+    {
+        intakeMotor.setSmartCurrentLimit(
+            Constants.MotorLimit.Neo550.stall,
+            Constants.MotorLimit.Neo550.free,
+            Constants.MotorLimit.Neo550.stallRPM);
+    }
+
     private final DigitalInput noteSensor = new DigitalInput(1);
     double voltage_scale_factor = 5/RobotController.getVoltage5V();
     double currentDistanceInches;

--- a/src/main/java/frc/robot/subsystems/arm/shooterSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/arm/shooterSubsystem.java
@@ -15,10 +15,17 @@ import edu.wpi.first.math.system.plant.DCMotor;
 import edu.wpi.first.math.system.plant.LinearSystemId;
 import edu.wpi.first.math.util.Units;
 import edu.wpi.first.wpilibj2.command.SubsystemBase;
+import frc.robot.Constants;
 
 public class shooterSubsystem extends SubsystemBase {
     
     private final CANSparkMax shooterMotor = new CANSparkMax(28, MotorType.kBrushless);
+    {
+        shooterMotor.setSmartCurrentLimit(
+            Constants.MotorLimit.Neo.stall,
+            Constants.MotorLimit.Neo.free,
+            Constants.MotorLimit.Neo.stallRPM);
+    }
     private final RelativeEncoder shooterEncoder = shooterMotor.getEncoder();
 
     public static double kSpinupRadPerSec = Units.rotationsPerMinuteToRadiansPerSecond(0);

--- a/src/main/java/frc/robot/subsystems/climber/climberLeftSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/climber/climberLeftSubsystem.java
@@ -5,11 +5,19 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.CANSparkLowLevel.MotorType;
+
+import frc.robot.Constants;
 import frc.robot.Constants.Climber;
 
 public class climberLeftSubsystem extends SubsystemBase{
 
     private final CANSparkMax climberMotorLeft = new CANSparkMax(22, MotorType.kBrushless);
+    {
+        climberMotorLeft.setSmartCurrentLimit(
+            Constants.MotorLimit.Neo550.stall,
+            Constants.MotorLimit.Neo550.free,
+            Constants.MotorLimit.Neo550.stallRPM);
+    }
 
     private final RelativeEncoder climberMotorLeftRelativeEncoder = climberMotorLeft.getEncoder();
 

--- a/src/main/java/frc/robot/subsystems/climber/climberRightSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/climber/climberRightSubsystem.java
@@ -5,11 +5,19 @@ import edu.wpi.first.wpilibj2.command.SubsystemBase;
 import com.revrobotics.CANSparkMax;
 import com.revrobotics.RelativeEncoder;
 import com.revrobotics.CANSparkLowLevel.MotorType;
+
+import frc.robot.Constants;
 import frc.robot.Constants.Climber;
 
 public class climberRightSubsystem extends SubsystemBase{
 
     private final CANSparkMax climberMotorRight = new CANSparkMax(21, MotorType.kBrushless);
+    {
+        climberMotorRight.setSmartCurrentLimit(
+            Constants.MotorLimit.Neo550.stall,
+            Constants.MotorLimit.Neo550.free,
+            Constants.MotorLimit.Neo550.stallRPM);
+    }
 
     private final RelativeEncoder climberMotorRightRelativeEncoder = climberMotorRight.getEncoder();
 


### PR DESCRIPTION
Add code and plumbing for setting motor current limits.  Currently pretty wide-open with RevRobotics recommended limits for each type of motor.  Change for specific subsystems as needed.

Not yet implemented: No current limiting for swerve drive motors.  I have no desire to dive into their library.

Caution: In a brownout, the default current limits will get reloaded by controllers (80A).  RevRobotics recommends writing these settings to flash with .BurnFlash() even if setting in software.  I didn't do that! See https://www.chiefdelphi.com/t/spark-max-current-limit/354333/3

Note: Not yet tested on physical robot.
Paves the way to quick fix (mostly) of Issue #11