### PR TITLE
Driver helper -- automatic aiming.

### DIFF
--- a/simgui-ds.json
+++ b/simgui-ds.json
@@ -1,4 +1,9 @@
 {
+  "Keyboard 0 Settings": {
+    "window": {
+      "visible": true
+    }
+  },
   "keyboardJoysticks": [
     {
       "axisConfig": [
@@ -11,17 +16,15 @@
           "incKey": 83
         },
         {
-          "decKey": 69,
-          "decayRate": 0.0,
-          "incKey": 82,
-          "keyRate": 0.009999999776482582
+          "decKey": 76,
+          "incKey": 74
         },
         {
-          "decKey": 75,
-          "incKey": 76
+          "decKey": 73,
+          "incKey": 75
         }
       ],
-      "axisCount": 5,
+      "axisCount": 4,
       "buttonCount": 4,
       "buttonKeys": [
         90,
@@ -44,14 +47,6 @@
       "povCount": 1
     },
     {
-      "axisConfig": [
-        {
-          "decKey": 74
-        },
-        {
-          "decKey": 73
-        }
-      ],
       "axisCount": 2,
       "buttonCount": 4,
       "buttonKeys": [
@@ -94,10 +89,6 @@
   "robotJoysticks": [
     {
       "guid": "Keyboard0"
-    },
-    {},
-    {
-      "useGamepad": true
     }
   ]
 }

--- a/simgui.json
+++ b/simgui.json
@@ -1,39 +1,24 @@
 {
   "HALProvider": {
     "Other Devices": {
-      "DutyCycleEncoder[4]": {
-        "header": {
-          "open": true
-        }
-      },
-      "SPARK MAX [25]": {
-        "header": {
-          "open": true
-        }
-      },
-      "SPARK MAX [26]": {
-        "header": {
-          "open": true
-        }
-      },
       "Talon FX[50]": {
         "header": {
-          "open": true
+          "open": false
         }
       },
       "Talon FX[51]/Integrated Sensor": {
         "header": {
-          "open": true
+          "open": false
         }
       },
       "Talon FX[52]/Integrated Sensor": {
         "header": {
-          "open": true
+          "open": false
         }
       },
       "Talon FX[8]/Integrated Sensor": {
         "header": {
-          "open": true
+          "open": false
         }
       }
     }
@@ -41,40 +26,16 @@
   "NTProvider": {
     "types": {
       "/FMSInfo": "FMSInfo",
-      "/LiveWindow/SwerveSubsystem": "Subsystem",
-      "/LiveWindow/Ungrouped/PIDController[1]": "PIDController",
-      "/LiveWindow/Ungrouped/Pigeon 2 [13]": "Gyro",
-      "/LiveWindow/Ungrouped/Scheduler": "Scheduler",
       "/SmartDashboard/Auto Chooser": "String Chooser",
-      "/SmartDashboard/Auto Mode": "String Chooser",
-      "/SmartDashboard/Example Auto": "Command",
       "/SmartDashboard/Field": "Field2d",
-      "/SmartDashboard/On-the-fly path": "Command",
-      "/SmartDashboard/Pathfind to Pickup Pos": "Command",
-      "/SmartDashboard/Pathfind to Scoring Pos": "Command",
-      "/SmartDashboard/Pigeon 2 (v6) [13]": "Gyro",
-      "/SmartDashboard/Pigeon 2 (v6) [14]": "Gyro",
-      "/SmartDashboard/Pigeon 2 [13]": "Gyro",
-      "/SmartDashboard/SendableChooser[0]": "String Chooser",
-      "/SmartDashboard/navX-Sensor[1]": "Gyro"
+      "/SmartDashboard/Pigeon 2 (v6) [14]": "Gyro"
     },
     "windows": {
-      "/SmartDashboard/Auto Chooser": {
-        "window": {
-          "visible": true
-        }
-      },
       "/SmartDashboard/Field": {
         "XModules": {
-          "arrowColor": [
-            0.09611687064170837,
-            0.17414122819900513,
-            0.9803921580314636,
-            255.0
-          ],
-          "arrowSize": 33,
-          "arrowWeight": 3.0,
-          "style": "Hidden"
+          "arrowSize": 0,
+          "arrowWeight": 0.0,
+          "style": ""
         },
         "bottom": 1476,
         "height": 8.210550308227539,
@@ -85,29 +46,25 @@
         "window": {
           "visible": true
         }
+      },
+      "/SmartDashboard/Pigeon 2 (v6) [14]": {
+        "window": {
+          "visible": true
+        }
       }
     }
   },
   "NetworkTables": {
     "transitory": {
       "SmartDashboard": {
+        "Driver Helper": {
+          "open": true
+        },
         "open": true,
         "swerve": {
-          "open": true
+          "open": false
         }
       }
     }
-  },
-  "NetworkTables Info": {
-    "Connections": {
-      "open": true
-    },
-    "Server": {
-      "Publishers": {
-        "open": true
-      },
-      "open": true
-    },
-    "visible": true
   }
 }

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -8,8 +8,8 @@ import com.pathplanner.lib.util.HolonomicPathFollowerConfig;
 import com.pathplanner.lib.util.PIDConstants;
 import com.pathplanner.lib.util.ReplanningConfig;
 
-//import edu.wpi.first.apriltag.AprilTagFieldLayout;
-//import edu.wpi.first.apriltag.AprilTagFields;
+import edu.wpi.first.apriltag.AprilTagFieldLayout;
+import edu.wpi.first.apriltag.AprilTagFields;
 //import edu.wpi.first.math.Matrix;
 //import edu.wpi.first.math.VecBuilder;
 import edu.wpi.first.math.geometry.Pose3d;
@@ -21,6 +21,8 @@ import edu.wpi.first.math.geometry.Translation3d;
 //import edu.wpi.first.math.numbers.N3;
 import edu.wpi.first.math.util.Units;
 import swervelib.math.Matter;
+
+import java.io.IOException;
 import java.util.List;
 import swervelib.parser.PIDFConfig;
 
@@ -94,6 +96,27 @@ public final class Constants
     public static final double kAmpShootPos = Math.toRadians(90); //0.269*Math.PI*2;//0.665
     public static final double kClimbingandFrontSpeakerShootPos = Math.toRadians(18); //was 15, changed to 18 to compensate for bad offset0.396*Math.PI*2; //0.396
     public static final double kIntakePos = Math.toRadians(5);
+  }
+
+  private static final AprilTagFieldLayout loadAprilTagLayoutFromFile() {
+    try {
+      var aprilTagLayout = AprilTagFieldLayout.loadFromResource(AprilTagFields.k2024Crescendo.m_resourceFile);
+      return aprilTagLayout;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static class AimTargets {
+    public static final Pose3d defaultTarget = new Pose3d(8.0, 4.0, 2.0, new Rotation3d()); // Near center of field.
+    public static final AprilTagFieldLayout aprilTagLayout = loadAprilTagLayoutFromFile();
+
+    public static final Transform3d tagToSpeaker = new Transform3d(0.0, 0.0, Units.inchesToMeters(6.0), // FIXME: get real dimensions.
+                                                                   new Rotation3d(0.0, Math.toRadians(157.5), 0.0)); // Get real rotation (currently unused)
+
+    public static final Pose3d blueSpeaker = aprilTagLayout.getTagPose(7)
+                                                           .orElse(defaultTarget)
+                                                           .plus(tagToSpeaker);
   }
 
   public static class OperatorConstants

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -34,6 +34,7 @@ import swervelib.parser.PIDFConfig;
  */
 public final class Constants
 {
+  public static final double TAU = 2*Math.PI;
 
   public static final double ROBOT_MASS = (97) * 0.453592; // 32lbs * kg per pound
   public static final Matter CHASSIS    = new Matter(new Translation3d(Units.inchesToMeters(0), Units.inchesToMeters(0), Units.inchesToMeters(8
@@ -77,8 +78,12 @@ public final class Constants
     public static final double kSVolts = 0.8; //try 0.8 if it doesn't work
     public static final double kP = 45; //tiny oscillation at 50
     public static final double kMaxAccelerationRadPerSecSquared = 1;
-    //public static final double kArmOffsetRads = Math.PI/2;
-    public static final double kEncoderDistancePerRotation = 2*Math.PI;
+    public static final class Encoder {
+      public static final double kDistancePerRotation = TAU;
+      public static final double kOffset  = 0.386; // Radians
+      public static final double kSafeMin = Math.toRadians(3);
+      public static final double kSafeMax = Math.toRadians(100);
+    }
     public static final double kStartingPos = Math.toRadians(75);//0.214*Math.PI*2;//0.610
     public static final double kAmpShootPos = Math.toRadians(90); //0.269*Math.PI*2;//0.665
     public static final double kClimbingandFrontSpeakerShootPos = Math.toRadians(18); //was 15, changed to 18 to compensate for bad offset0.396*Math.PI*2; //0.396

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -15,7 +15,7 @@ import com.pathplanner.lib.util.ReplanningConfig;
 import edu.wpi.first.math.geometry.Pose3d;
 import edu.wpi.first.math.geometry.Rotation2d;
 import edu.wpi.first.math.geometry.Rotation3d;
-//import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.math.geometry.Transform3d;
 import edu.wpi.first.math.geometry.Translation3d;
 //import edu.wpi.first.math.numbers.N1;
 //import edu.wpi.first.math.numbers.N3;
@@ -78,6 +78,12 @@ public final class Constants
     public static final double kSVolts = 0.8; //try 0.8 if it doesn't work
     public static final double kP = 45; //tiny oscillation at 50
     public static final double kMaxAccelerationRadPerSecSquared = 1;
+    public static final double armToShooterAngle = Math.toRadians(-120.0); // because I'm afraid there is more than one solution if I read back from pivotToShooter.
+    public static final Transform3d pivotToShooter = new Transform3d(Units.inchesToMeters(24.0), 0.0, 0.0,
+                                                                     new Rotation3d(0.0, armToShooterAngle, 0.0));
+    public static final Transform3d botToPivot = new Transform3d(Units.inchesToMeters(-8.0), 0.0, Units.inchesToMeters(9.75),
+                                                                 new Rotation3d(0.0, 0.0, 0.00));
+
     public static final class Encoder {
       public static final double kDistancePerRotation = TAU;
       public static final double kOffset  = 0.386; // Radians

--- a/src/main/java/frc/robot/Constants.java
+++ b/src/main/java/frc/robot/Constants.java
@@ -95,7 +95,8 @@ public final class Constants
     public static final double ROTATION_DEADBAND = 0.25;
 
     public static final double TURN_CONSTANT = 15;
-     
+
+    public static final double kSensitivity = 3.0;
   }
 
     public static class Vision {

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -119,6 +119,7 @@ public class Robot extends TimedRobot {
   }
   @Override
   public void teleopPeriodic() {
+    m_robotContainer.periodicUpdateDriverHelper();
   }
   @Override
   public void testInit() {

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -125,11 +125,6 @@ public class Robot extends TimedRobot {
   public void testInit() {
     // Cancels all running commands at the start of test mode.
     CommandScheduler.getInstance().cancelAll();
-    try {
-      new SwerveParser(new File(Filesystem.getDeployDirectory(), "swerve"));
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
   }
   @Override
   public void testPeriodic() {

--- a/src/main/java/frc/robot/Robot.java
+++ b/src/main/java/frc/robot/Robot.java
@@ -6,20 +6,15 @@ package frc.robot;
 
 
 //import com.pathplanner.lib.server.PathPlannerServer;
-import edu.wpi.first.wpilibj.Filesystem;
 import edu.wpi.first.wpilibj.TimedRobot;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj2.command.Command;
 import edu.wpi.first.wpilibj2.command.CommandScheduler;
 
-import java.io.File;
-import java.io.IOException;
 import edu.wpi.first.cameraserver.CameraServer;
-import edu.wpi.first.cscore.MjpegServer;
 import edu.wpi.first.cscore.UsbCamera;
 import edu.wpi.first.net.PortForwarder;
 import edu.wpi.first.util.PixelFormat;
-import swervelib.parser.SwerveParser;
 
 /**
  * The VM is configured to automatically run this class, and to call the functions corresponding to each mode, as

--- a/src/main/java/frc/robot/commands/arm/ContinuousPosCommand.java
+++ b/src/main/java/frc/robot/commands/arm/ContinuousPosCommand.java
@@ -1,0 +1,35 @@
+package frc.robot.commands.arm;
+
+import java.util.function.DoubleSupplier;
+
+import edu.wpi.first.wpilibj2.command.Command;
+import frc.robot.subsystems.arm.armSubsystem;
+
+public class ContinuousPosCommand extends Command {
+
+  private final armSubsystem m_ArmSubsystem;
+  private final DoubleSupplier desiredAngleSupplier;
+
+  public ContinuousPosCommand(armSubsystem subsystem,
+                              DoubleSupplier desiredAngleSupplier) {
+    m_ArmSubsystem = subsystem;
+    this.desiredAngleSupplier = desiredAngleSupplier;
+    addRequirements(m_ArmSubsystem);
+  }
+
+  @Override
+  public void initialize() {
+    m_ArmSubsystem.setSafeGoal(m_ArmSubsystem.getMeasurement());
+    if (!m_ArmSubsystem.isEnabled()) {
+      m_ArmSubsystem.enable();
+    }
+  }
+
+  @Override
+  public void execute() {
+    double desiredAngle = desiredAngleSupplier.getAsDouble();
+    m_ArmSubsystem.setSafeGoal(desiredAngle);
+    // System.out.println("position error: " + m_ArmSubsystem.showPositionError());
+  }
+
+}

--- a/src/main/java/frc/robot/commands/swervedrive/drivebase/AbsoluteDrive.java
+++ b/src/main/java/frc/robot/commands/swervedrive/drivebase/AbsoluteDrive.java
@@ -10,7 +10,6 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants;
 import frc.robot.subsystems.swervedrive.SwerveSubsystem;
-import java.util.List;
 import java.util.function.DoubleSupplier;
 import swervelib.SwerveController;
 import swervelib.math.SwerveMath;

--- a/src/main/java/frc/robot/commands/swervedrive/drivebase/AbsoluteDriveAdv.java
+++ b/src/main/java/frc/robot/commands/swervedrive/drivebase/AbsoluteDriveAdv.java
@@ -11,7 +11,6 @@ import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
 import edu.wpi.first.wpilibj2.command.Command;
 import frc.robot.Constants;
 import frc.robot.subsystems.swervedrive.SwerveSubsystem;
-import java.util.List;
 import java.util.function.BooleanSupplier;
 import java.util.function.DoubleSupplier;
 import swervelib.SwerveController;

--- a/src/main/java/frc/robot/subsystems/arm/armSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/arm/armSubsystem.java
@@ -12,7 +12,7 @@ import com.revrobotics.CANSparkLowLevel.MotorType;
 import edu.wpi.first.math.controller.ArmFeedforward;
 import edu.wpi.first.math.controller.ProfiledPIDController;
 import edu.wpi.first.math.trajectory.TrapezoidProfile;
-import edu.wpi.first.math.trajectory.TrapezoidProfile.State;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.wpilibj.DutyCycleEncoder;
 import frc.robot.Constants;
 import frc.robot.Constants.Arm;
@@ -49,15 +49,19 @@ public class armSubsystem extends ProfiledPIDSubsystem {
                 Arm.kMaxVelocityRadPerSecond,
                 Arm.kMaxAccelerationRadPerSecSquared))//, Arm.kStartingPos
                 );//add 0 
-    m_encoder.setPositionOffset(0.386);
-    m_encoder.setDistancePerRotation(Arm.kEncoderDistancePerRotation);
+    m_encoder.setPositionOffset(Arm.Encoder.kOffset);
+    m_encoder.setDistancePerRotation(Arm.Encoder.kDistancePerRotation);
     leftMotor.setInverted(false);
     rightMotor.setInverted(true);
     // Start arm at rest in neutral position
-    //setGoal(Arm.kArmOffsetRads);
-    setGoal(Arm.kStartingPos);
+    setSafeGoal(Arm.kStartingPos);
 
     //enable();
+  }
+
+  public final void setSafeGoal(double goal) {
+    goal = MathUtil.clamp(goal, Arm.Encoder.kSafeMin, Arm.Encoder.kSafeMax);
+    setGoal(goal);
   }
 
   @Override

--- a/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
+++ b/src/main/java/frc/robot/subsystems/swervedrive/SwerveSubsystem.java
@@ -298,8 +298,8 @@ public class SwerveSubsystem extends SubsystemBase {
    * @return {@link ChassisSpeeds} which can be sent to th Swerve Drive.
    */
   public ChassisSpeeds getTargetSpeeds(double xInput, double yInput, double headingX, double headingY) {
-    xInput = Math.pow(xInput, 3);
-    yInput = Math.pow(yInput, 3);
+    xInput = adjustSensitivity(xInput);
+    yInput = adjustSensitivity(yInput);
     return swerveDrive.swerveController.getTargetSpeeds(xInput, yInput, headingX, headingY, getHeading().getRadians(), maximumSpeed);  
   }
 
@@ -312,8 +312,8 @@ public class SwerveSubsystem extends SubsystemBase {
    * @return {@link ChassisSpeeds} which can be sent to th Swerve Drive.
    */
   public ChassisSpeeds getTargetSpeeds(double xInput, double yInput, Rotation2d angle) {
-    xInput = Math.pow(xInput, 3);
-    yInput = Math.pow(yInput, 3);
+    xInput = adjustSensitivity(xInput);
+    yInput = adjustSensitivity(yInput);
     return swerveDrive.swerveController.getTargetSpeeds(xInput,
                                                         yInput,
                                                         angle.getRadians(),
@@ -398,6 +398,13 @@ public class SwerveSubsystem extends SubsystemBase {
     visionPose.ifPresent(this.visionPoseConsumer);
     
 }
+
+  private static double adjustSensitivity(double value) {
+    double sign = Math.signum(value);
+    double absvalue = Math.abs(value);
+    value = sign * Math.pow(absvalue, Constants.OperatorConstants.kSensitivity);
+    return value;
+  }
 
   /**
    * Factory to fetch the PathPlanner command to follow the defined path.

--- a/src/main/java/frc/robot/utils/DriverHelper.java
+++ b/src/main/java/frc/robot/utils/DriverHelper.java
@@ -61,7 +61,7 @@ public class DriverHelper implements Sendable {
     var driverInput = -driverHeadingX.getAsDouble();
     if(passthrough) { 
       return driverInput; };
-    if(Math.abs(driverInput) > driverDeadband) {
+    if(isDriverOverride()) {
       return driverInput; }
 
     var heading = headingDirection.getTranslation();
@@ -76,7 +76,7 @@ public class DriverHelper implements Sendable {
     var driverInput = -driverHeadingY.getAsDouble();
     if(passthrough) { 
       return driverInput; };
-    if(Math.abs(driverInput) > driverDeadband) {
+    if(isDriverOverride()) {
       return driverInput; }
 
     var heading = headingDirection.getTranslation();
@@ -116,6 +116,12 @@ public class DriverHelper implements Sendable {
      *   var launchDirection2d = new Translation2d(launchDirectionXYProjLength, launchDirection.getZ());
      */
     return launchDirectionAngleToXYPlane;
+  }
+
+  private boolean isDriverOverride() {
+    // FIXME: Is there any guarantee we get consistent, unchanging readings from DriverStation throughout an iteration?
+    var magnitude = Math.hypot(driverHeadingX.getAsDouble(), driverHeadingY.getAsDouble());
+    return (magnitude > driverDeadband);
   }
 
   @Override

--- a/src/main/java/frc/robot/utils/DriverHelper.java
+++ b/src/main/java/frc/robot/utils/DriverHelper.java
@@ -1,0 +1,137 @@
+package frc.robot.utils;
+
+import java.util.function.DoubleSupplier;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Pose3d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Rotation3d;
+import edu.wpi.first.math.geometry.Transform3d;
+import edu.wpi.first.util.sendable.Sendable;
+import edu.wpi.first.util.sendable.SendableBuilder;
+import frc.robot.Constants;
+
+public class DriverHelper implements Sendable {
+  public DoubleSupplier headingX = () -> this.getHeadingX();
+  public DoubleSupplier headingY = () -> this.getHeadingY();
+  public DoubleSupplier armAngle = () -> this.getArmAngle();
+
+  private DoubleSupplier driverHeadingX;
+  private DoubleSupplier driverHeadingY;
+
+  private boolean passthrough = true;
+  private Pose3d targetPose = new Pose3d();
+  private Pose3d lastBotPose = new Pose3d();
+  private Pose3d shooterPose = new Pose3d();
+  private Pose3d launchDirection = new Pose3d();
+  private Pose2d headingDirection = new Pose2d();
+
+  public double driverDeadband = Constants.OperatorConstants.ROTATION_DEADBAND;
+
+  public DriverHelper(DoubleSupplier driverHeadingXSupplier,
+                       DoubleSupplier driverHeadingYSupplier) {
+    driverHeadingX = driverHeadingXSupplier;
+    driverHeadingY = driverHeadingYSupplier;
+  }
+
+  public void setPassThrough() {
+    passthrough = true;
+  }
+
+  public void setTargetPose(Pose3d target) {
+    passthrough = false;
+    targetPose = target;
+  }
+
+  public void updateAim(Pose2d botPose2d) {
+    var botPose = new Pose3d(botPose2d);
+    lastBotPose = botPose;
+    var armRotation = new Transform3d(0.0, 0.0, 0.0,
+                                      new Rotation3d(0.0, -getArmAngle(), 0.0)); // Note: using last iteration result; This could become a stability problem.
+    shooterPose = botPose.plus(Constants.Arm.botToPivot)
+                         .plus(armRotation)
+                         .plus(Constants.Arm.pivotToShooter); // Note: Order is important!
+    var shooterPoseUpright = new Pose3d(shooterPose.getTranslation(), new Rotation3d());
+    launchDirection = targetPose.relativeTo(shooterPoseUpright);
+    headingDirection = launchDirection.toPose2d()
+                                      .rotateBy(new Rotation2d(Constants.TAU/2)); // Robot shoots in the -X direction.
+  }
+
+  public double getHeadingX() {
+    var driverInput = -driverHeadingX.getAsDouble();
+    if(passthrough) { 
+      return driverInput; };
+    if(Math.abs(driverInput) > driverDeadband) {
+      return driverInput; }
+
+    var heading = headingDirection.getTranslation();
+    var helperInput = heading.getX()/heading.getNorm();
+
+    if(!Double.isFinite(helperInput)) {
+      helperInput = 0.0; }
+    return helperInput;
+  }
+
+  public double getHeadingY() {
+    var driverInput = -driverHeadingY.getAsDouble();
+    if(passthrough) { 
+      return driverInput; };
+    if(Math.abs(driverInput) > driverDeadband) {
+      return driverInput; }
+
+    var heading = headingDirection.getTranslation();
+    var helperInput = heading.getY()/heading.getNorm();
+
+    if(!Double.isFinite(helperInput)) {
+      helperInput = 0.0; }
+    return helperInput;
+  }
+
+  public double getArmAngle() {
+    if(passthrough) {
+      return Constants.Arm.kStartingPos; } // We really shouldn't be called now!
+    double armShooterAngleOffset = Constants.Arm.armToShooterAngle;
+    double armAngle = (Constants.TAU/2 - ballisticTrajectoryLaunchAngle()) + armShooterAngleOffset;
+
+    if(!Double.isFinite(armAngle)) {
+      armAngle = Constants.Arm.kStartingPos; }
+    return armAngle;
+  }
+
+  private double ballisticTrajectoryLaunchAngle() {
+    // FIXME: Solution (no air resistance) is already well known.  See https://en.wikipedia.org/wiki/Projectile_motion#Angle_θ_required_to_hit_coordinate_(x,_y)
+    // FIXME: For air resistance: Since we only need a single point solution, with similar launch speed, similar environment, we can probably get away with adding a "drag" coefficient to distance we aim.
+    // FIXME: Using straight line trajectory for now.
+    var launchDirectionXYProjection = launchDirection.toPose2d();
+    var launchDirectionXYProjLength = launchDirectionXYProjection.getTranslation().getNorm();
+    var launchDirectionAngleToXYPlane = Math.atan2(launchDirection.getZ(), launchDirectionXYProjLength);
+    /* To demonstrate "visually," but more roundabout approach:
+     *   var launchDirectionXYArgument = launchDirectionXYProjection.getTranslation().getAngle();
+     *   var launchDirectionRotatedToXZ = launchDirection.rotateBy(new Rotation3d(0.0,0.0, -launchDirectionXYArgument.getRadians()));
+     *   var launchDirectionRotatedToXY = launchDirectionRotatedToXZ.rotateBy(new Rotation3d(-(TAU/4), 0.0, 0.0))
+                                                                    .toPose2d();
+     *   var launchDirectionAngle = launchDirectionRotatedToXY.getTranslation().getAngle();
+     */
+    /* FIXME: For future parabolic solution use:
+     *   var launchDirection2d = new Translation2d(launchDirectionXYProjLength, launchDirection.getZ());
+     */
+    return launchDirectionAngleToXYPlane;
+  }
+
+  @Override
+  public void initSendable(SendableBuilder builder) {
+    builder.setSmartDashboardType("Utility");
+
+    builder.addBooleanProperty("isPassThrough", () -> this.passthrough, null);
+    builder.addDoubleProperty("headingX", headingX, null);
+    builder.addDoubleProperty("headingY", headingY, null);
+    builder.addDoubleProperty("armAngle", armAngle, null);
+    builder.addDoubleProperty("driverHeadingX", driverHeadingX, null);
+    builder.addDoubleProperty("driverHeadingY", driverHeadingY, null);
+    builder.addStringProperty("lastBotPose", () -> this.lastBotPose.getTranslation().toString(), null);
+    builder.addStringProperty("shooterPose", () -> this.shooterPose.getTranslation().toString(), null);
+    builder.addStringProperty("targetPose", () -> this.targetPose.getTranslation().toString(), null);
+    builder.addStringProperty("launchDirection", () -> this.launchDirection.getTranslation().toString(), null);
+    builder.addStringProperty("headingDirection", () -> this.headingDirection.getTranslation().toString(), null);
+  }
+}


### PR DESCRIPTION
This series of commits lay down the infrastructure for assisting the driver/operator.

It aims automatically when enabled.  Driver can still command the robot; driver heading input wins over the "helper."

It's there to follow the target, but it doesn't interfere if the driver makes other inputs.  I think of it like "autopilot," except it doesn't "disconnect" when driver overrides it.

- Add `setSafeGoal()` method to `armSubsystem`.  We don't want to give it unconstrained input.  Reorganize some constants to `Constants::Arm::Encoder`.  Move hard-coded encoder offset to `Constraints`.
- Add command `ContinuousPosCommand` that uses the `armSubsystem`.
- Add `DriverHelper` utility.  It can help automatic aiming by altering heading and arm angle.
- Add `Constants::AimTargets` basing positions on `AprilTagFieldLayout`.  This will become useful while using `DriverHelper`.
- Example use of `DriverHelper`.
- Clean up: no more exception in `Robot::testInit`.
- Cosmetic: Clean up unused imports. (and warnings.)
- Simulation GUI setup changes.

This series of commits should hopefully be clear enough to follow.   I tried to break it up into sensible bites.